### PR TITLE
Union py39

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python: ["3.10", "3.11", "3.12", "3.13"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: compas-dev/compas-actions.build@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fixed `compas_pb` support in Python3.9.
+
 ### Removed
 
 
@@ -21,7 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added module `compas_pb.invocations` which offers re-usable protobuf related tasks for plugins. 
 
 ### Changed
-* remove `PrimitiveData` into `AnyData` with `Google.WellKownType.value`
+
+* remove `PrimitiveData` into `AnyData` with `Google.WellKownType.value`.
 
 ### Removed
 

--- a/src/compas_pb/api.py
+++ b/src/compas_pb/api.py
@@ -1,5 +1,6 @@
 from typing import Dict
 from typing import List
+from typing import Union
 
 from compas.data import Data
 
@@ -9,12 +10,12 @@ from compas_pb.core import serialize_message_bts
 from compas_pb.core import serialize_message_to_json
 
 
-def pb_dump(data: Data | Dict[str, Data] | List[Data], filepath: str) -> None:
+def pb_dump(data: Union[Data, Dict[str, Data], List[Data]], filepath: str) -> None:
     """Write a collection of COMPAS object to a binary file.
 
     Parameters
     ----------
-    data : Data | Dict | List
+    data : Union[Data, Dict, List]
         Any  protobuffer serializable object.
         This includes any (combination of) COMPAS object(s).
     filepath : path string or file-like object
@@ -31,7 +32,7 @@ def pb_dump(data: Data | Dict[str, Data] | List[Data], filepath: str) -> None:
         f.write(message_bts)
 
 
-def pb_load(filepath: str) -> Data | Dict | List:
+def pb_load(filepath: str) -> Union[Data, Dict, List]:
     """Read a collection of COMPAS object from a binary file.
 
     Parameters
@@ -42,7 +43,7 @@ def pb_load(filepath: str) -> Data | Dict | List:
 
     Returns
     -------
-    Data | Dict | List
+    Union[Data, Dict, List]
 
         The (COMPAS) object(s) contained in the file.
 
@@ -54,13 +55,13 @@ def pb_load(filepath: str) -> Data | Dict | List:
         return message
 
 
-def pb_dump_json(data: Data | Dict | List) -> str:
+def pb_dump_json(data: Union[Data, Dict, List]) -> str:
     """Write a collection of COMPAS object to a JSON string.
 
 
     Parameters
     ----------
-    data : Data | Dict | List
+    data : Union[Data, Dict, List]
 
         Any  protobuffer serializable object. This includes any (combination of) COMPAS object(s).
 
@@ -76,7 +77,7 @@ def pb_dump_json(data: Data | Dict | List) -> str:
     return json_str
 
 
-def pb_load_json(data: str) -> Data | Dict | List:
+def pb_load_json(data: str) -> Union[Data, Dict, List]:
     """Read a collection of COMPAS object from a JSON string.
 
 
@@ -89,7 +90,7 @@ def pb_load_json(data: str) -> Data | Dict | List:
 
     Returns
     -------
-    Data | Dict | List
+    Union[Data, Dict, List]
 
 
         The (COMPAS) object(s) contained in the JSON string.
@@ -99,13 +100,13 @@ def pb_load_json(data: str) -> Data | Dict | List:
     return message
 
 
-def pb_dump_bts(data: Data | Dict | list) -> bytes:
+def pb_dump_bts(data: Union[Data, Dict, list]) -> bytes:
     """Write a collection of COMPAS object to a btye string.
 
 
     Parameters
     ----------
-    data : Data | Dict | List
+    data : Union[Data, Dict, List]
 
         Any  protobuffer serializable object.
         This includes any (combination of) COMPAS object(s).
@@ -120,7 +121,7 @@ def pb_dump_bts(data: Data | Dict | list) -> bytes:
     return message_bts
 
 
-def pb_load_bts(data: bytes) -> Data | Dict | List:
+def pb_load_bts(data: bytes) -> Union[Data, Dict, List]:
     """Read a collection of COMPAS object from a binary file.
 
     Parameters
@@ -131,7 +132,7 @@ def pb_load_bts(data: bytes) -> Data | Dict | List:
 
     Returns
     -------
-    Data | Dict | List
+    Union[Data, Dict, List]
         The (COMPAS) object(s) contained in the file.
 
     """

--- a/src/compas_pb/conversions.py
+++ b/src/compas_pb/conversions.py
@@ -43,7 +43,6 @@ from compas_pb.generated import vector_pb2
 from .registry import pb_deserializer
 from .registry import pb_serializer
 
-
 # =============================================================================
 # Point
 # =============================================================================

--- a/src/compas_pb/core.py
+++ b/src/compas_pb/core.py
@@ -1,4 +1,5 @@
 import base64
+from typing import Union
 
 import compas
 from compas.plugins import pluggable
@@ -28,7 +29,7 @@ def _discover_serializers() -> None:
     _DISCOVERY_DONE = True
 
 
-def primitive_to_pb(obj: int | float | bool | str | bytes) -> message_pb2.AnyData:
+def primitive_to_pb(obj: Union[int, float, bool, str, bytes]) -> message_pb2.AnyData:
     """
     Convert a python native type to a protobuf message.
 
@@ -65,7 +66,7 @@ def primitive_to_pb(obj: int | float | bool | str | bytes) -> message_pb2.AnyDat
     return data_offset
 
 
-def primitive_from_pb(primitive: message_pb2.AnyData) -> int | float | bool | str | bytes:
+def primitive_from_pb(primitive: message_pb2.AnyData) -> Union[int, float, bool, str, bytes]:
     """Convert a protobuf message to a python native type.
 
     Parameters
@@ -75,7 +76,7 @@ def primitive_from_pb(primitive: message_pb2.AnyData) -> int | float | bool | st
 
     Returns
     -------
-    data_offset : int | float | bool | str | bytes
+    data_offset : Union[int, float, bool, str, bytes]
         The converted python native type.
     """
     type_ = primitive.value.WhichOneof("kind")
@@ -97,12 +98,12 @@ def primitive_from_pb(primitive: message_pb2.AnyData) -> int | float | bool | st
     return data_offset
 
 
-def any_to_pb(obj: compas.data.Data | int | float | bool | str | bytes, fallback_serializer=None) -> message_pb2.AnyData:
+def any_to_pb(obj: Union[compas.data.Data, int, float, bool, str, bytes], fallback_serializer=None) -> message_pb2.AnyData:
     """Convert any object to a protobuf any message.
 
     Parameters
     ----------
-    obj : compas.data.Data | list | dict | int | float | bool | str
+    obj : Union[compas.data.Data, list, dict, int, float, bool, str]
         The object to convert. Can be a COMPAS Data object, list, dict, or primitive type.
 
     Returns
@@ -133,7 +134,7 @@ def any_to_pb(obj: compas.data.Data | int | float | bool | str | bytes, fallback
         raise TypeError(f"Unsupported type: {type(obj)}: {e}")
 
 
-def any_from_pb(proto_data: message_pb2.AnyData) -> compas.data.Data | int | float | bool | str | bytes:
+def any_from_pb(proto_data: message_pb2.AnyData) -> Union[compas.data.Data, int, float, bool, str, bytes]:
     """Convert a protobuf message to a supported object.
 
     Parameters
@@ -143,7 +144,7 @@ def any_from_pb(proto_data: message_pb2.AnyData) -> compas.data.Data | int | flo
 
     Returns
     -------
-    compas.data.Data | list | dict | int | float | bool | str
+    Union[compas.data.Data, list, dict, int, float, bool, str]
         The converted object. Can be a COMPAS Data object, list, dict, or primitive type.
     """
     _discover_serializers()
@@ -256,7 +257,7 @@ def _serialize_dict(data_dict) -> message_pb2.DictData:
     return dict_data
 
 
-def deserialize_message(binary_data) -> list | dict:
+def deserialize_message(binary_data) -> Union[list, dict]:
     """Deserialize a top-level protobuf message.
 
     Parameters
@@ -266,7 +267,7 @@ def deserialize_message(binary_data) -> list | dict:
 
     Returns
     -------
-    message : list | dict
+    message : Union[list, dict]
         The deserialized protobuf message.
 
     """
@@ -322,7 +323,7 @@ def deserialize_message_from_json(json_data: str) -> dict:
     return _deserialize_any(any_data.data)
 
 
-def _deserialize_any(data: message_pb2.AnyData | message_pb2.ListData | message_pb2.DictData) -> list | dict:
+def _deserialize_any(data: Union[message_pb2.AnyData, message_pb2.ListData, message_pb2.DictData]) -> Union[list, dict]:
     """Deserialize a protobuf message to COMPAS object."""
     if data.message.Is(message_pb2.ListData.DESCRIPTOR):
         data_offset = _deserialize_list(data)

--- a/src/compas_pb/invocations.py
+++ b/src/compas_pb/invocations.py
@@ -1,12 +1,13 @@
+import gzip
 import os
-import stat
-from pathlib import Path
-import invoke
 import platform
+import stat
+import tarfile
 import urllib.request
 import zipfile
-import tarfile
-import gzip
+from pathlib import Path
+
+import invoke
 
 PROTOC_VERSION = "31.1"
 PROTOC_GEN_DOCS_VERSION = "1.5.1"


### PR DESCRIPTION
Changed `|` operator in typing to `Union` since the former is apparently not supported yet in python3.9 (thanks Rhino..)
Also added python 3.9 to build matrix

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
