### PR TITLE
Fallback (de)serialization based on `compas.data.Data`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * added `.proto` file into build package.
+* Added `FallbackData` member `fallback` to `AnyData` to allow for fallback serialization of unknown types.
 
 ### Changed
 

--- a/src/compas_pb/core.py
+++ b/src/compas_pb/core.py
@@ -18,6 +18,10 @@ def _ensure_serializers():
     PLUGIN_MANAGER.discover_plugins()
 
 
+def _decode_dict(data_dict: dict) -> Data:
+    return DataDecoder().object_hook(data_dict)
+
+
 def primitive_to_pb(obj: Union[int, float, bool, str, bytes]) -> message_pb2.AnyData:
     """
     Convert a python native type to a protobuf message.
@@ -356,4 +360,4 @@ def _deserialize_dict(data_dict: message_pb2.AnyData) -> dict:
 def _deserialize_fallback(data_dict: message_pb2.AnyData) -> Data:
     """Fallback deserializer to convert a protobuf FallbackData message to Python dictionary."""
     obj_data = _deserialize_dict(data_dict.fallback.data)
-    return DataDecoder().object_hook(obj_data)
+    return _decode_dict(obj_data)

--- a/src/compas_pb/core.py
+++ b/src/compas_pb/core.py
@@ -119,8 +119,7 @@ def any_to_pb(obj: Union[compas.data.Data, int, float, bool, str, bytes]) -> mes
         elif isinstance(obj, Data):
             proto_data = _serialize_fallback(obj)
         else:
-            primitive = primitive_to_pb(obj)
-            proto_data = primitive
+            proto_data = primitive_to_pb(obj)
         return proto_data
     except TypeError as e:
         raise TypeError(f"Unsupported type: {type(obj)}: {e}")

--- a/src/compas_pb/core.py
+++ b/src/compas_pb/core.py
@@ -92,7 +92,7 @@ def primitive_from_pb(primitive: message_pb2.AnyData) -> Union[int, float, bool,
     return data_offset
 
 
-def any_to_pb(obj: Union[compas.data.Data, int, float, bool, str, bytes], fallback_serializer=None) -> message_pb2.AnyData:
+def any_to_pb(obj: Union[compas.data.Data, int, float, bool, str, bytes]) -> message_pb2.AnyData:
     """Convert any object to a protobuf any message.
 
     Parameters
@@ -236,7 +236,7 @@ def _serializer_any(obj) -> message_pb2.AnyData:
         any_data.message.Pack(data_offset)
     else:
         # check if it is COMPAS object or Python native type or fallback to dictionary.
-        any_data = any_to_pb(obj, fallback_serializer=_serialize_dict)
+        any_data = any_to_pb(obj)
     return any_data
 
 

--- a/src/compas_pb/core.py
+++ b/src/compas_pb/core.py
@@ -140,13 +140,17 @@ def any_from_pb(proto_data: message_pb2.AnyData) -> Union[compas.data.Data, int,
     """
     _ensure_serializers()
 
-    if proto_data.WhichOneof("data") == "value":
+    union_field = proto_data.WhichOneof("data")
+    if union_field == "value":
         return primitive_from_pb(proto_data)
-    if proto_data.WhichOneof("data") == "fallback":
+    elif union_field == "fallback":
         return _deserialize_fallback(proto_data)
-    if proto_data.WhichOneof("data") == "message":
+
+    elif union_field == "message":
         # type.googleapis.com/<fully.qualified.message.name>
         proto_type = proto_data.message.type_url.split("/")[-1]
+    else:
+        raise NameError(f"Unexpected AnyData field: {union_field}")
 
     deserializer = SerializerRegistry.get_deserializer(proto_type)
     if not deserializer:

--- a/src/compas_pb/core.py
+++ b/src/compas_pb/core.py
@@ -1,4 +1,5 @@
 import base64
+from typing import Any
 from typing import Union
 
 import compas
@@ -145,12 +146,15 @@ def any_from_pb(proto_data: message_pb2.AnyData) -> Union[compas.data.Data, int,
         return primitive_from_pb(proto_data)
     elif union_field == "fallback":
         return _deserialize_fallback(proto_data)
-
     elif union_field == "message":
-        # type.googleapis.com/<fully.qualified.message.name>
-        proto_type = proto_data.message.type_url.split("/")[-1]
+        return _handle_known_type(proto_data)
     else:
         raise NameError(f"Unexpected AnyData field: {union_field}")
+
+
+def _handle_known_type(proto_data: message_pb2.AnyData) -> Any:
+    # type.googleapis.com/<fully.qualified.message.name>
+    proto_type = proto_data.message.type_url.split("/")[-1]
 
     deserializer = SerializerRegistry.get_deserializer(proto_type)
     if not deserializer:

--- a/src/compas_pb/core.py
+++ b/src/compas_pb/core.py
@@ -357,7 +357,7 @@ def _deserialize_list(data_list: message_pb2.ListData) -> list:
     return data_offset
 
 
-def _deserialize_dict(data_dict: message_pb2.AnyData) -> dict:
+def _deserialize_dict(data_dict: message_pb2.DictData) -> dict:
     """Deserialize a protobuf DictData message to Python dictionary."""
     data_offset = {}
     for key, value in data_dict.items.items():

--- a/src/compas_pb/core.py
+++ b/src/compas_pb/core.py
@@ -325,7 +325,9 @@ def deserialize_message_from_json(json_data: str) -> dict:
 def _deserialize_any(data: Union[message_pb2.AnyData, message_pb2.ListData, message_pb2.DictData]) -> Union[list, dict]:
     """Deserialize a protobuf message to COMPAS object."""
     if data.message.Is(message_pb2.ListData.DESCRIPTOR):
-        data_offset = _deserialize_list(data)
+        list_data = message_pb2.ListData()
+        data.message.Unpack(list_data)
+        data_offset = _deserialize_list(list_data)
     elif data.message.Is(message_pb2.DictData.DESCRIPTOR):
         dict_data = message_pb2.DictData()
         data.message.Unpack(dict_data)
@@ -338,9 +340,7 @@ def _deserialize_any(data: Union[message_pb2.AnyData, message_pb2.ListData, mess
 def _deserialize_list(data_list: message_pb2.ListData) -> list:
     """Deserialize a protobuf ListData message to Python list."""
     data_offset = []
-    list_data = message_pb2.ListData()
-    data_list.message.Unpack(list_data)
-    for item in list_data.items:
+    for item in data_list.items:
         data_offset.append(_deserialize_any(item))
     return data_offset
 

--- a/src/compas_pb/generated/message_pb2.py
+++ b/src/compas_pb/generated/message_pb2.py
@@ -26,7 +26,7 @@ from google.protobuf import any_pb2 as google_dot_protobuf_dot_any__pb2
 from google.protobuf import struct_pb2 as google_dot_protobuf_dot_struct__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n!compas_pb/generated/message.proto\x12\x0e\x63ompas_pb.data\x1a\x19google/protobuf/any.proto\x1a\x1cgoogle/protobuf/struct.proto\"c\n\x07\x41nyData\x12\'\n\x07message\x18\x01 \x01(\x0b\x32\x14.google.protobuf.AnyH\x00\x12\'\n\x05value\x18\x02 \x01(\x0b\x32\x16.google.protobuf.ValueH\x00\x42\x06\n\x04\x64\x61ta\"2\n\x08ListData\x12&\n\x05items\x18\x01 \x03(\x0b\x32\x17.compas_pb.data.AnyData\"\x85\x01\n\x08\x44ictData\x12\x32\n\x05items\x18\x01 \x03(\x0b\x32#.compas_pb.data.DictData.ItemsEntry\x1a\x45\n\nItemsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12&\n\x05value\x18\x02 \x01(\x0b\x32\x17.compas_pb.data.AnyData:\x02\x38\x01\"4\n\x0bMessageData\x12%\n\x04\x64\x61ta\x18\x01 \x01(\x0b\x32\x17.compas_pb.data.AnyDatab\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n!compas_pb/generated/message.proto\x12\x0e\x63ompas_pb.data\x1a\x19google/protobuf/any.proto\x1a\x1cgoogle/protobuf/struct.proto\"\x95\x01\n\x07\x41nyData\x12\'\n\x07message\x18\x01 \x01(\x0b\x32\x14.google.protobuf.AnyH\x00\x12\'\n\x05value\x18\x02 \x01(\x0b\x32\x16.google.protobuf.ValueH\x00\x12\x30\n\x08\x66\x61llback\x18\x03 \x01(\x0b\x32\x1c.compas_pb.data.FallbackDataH\x00\x42\x06\n\x04\x64\x61ta\"6\n\x0c\x46\x61llbackData\x12&\n\x04\x64\x61ta\x18\x01 \x01(\x0b\x32\x18.compas_pb.data.DictData\"2\n\x08ListData\x12&\n\x05items\x18\x01 \x03(\x0b\x32\x17.compas_pb.data.AnyData\"\x85\x01\n\x08\x44ictData\x12\x32\n\x05items\x18\x01 \x03(\x0b\x32#.compas_pb.data.DictData.ItemsEntry\x1a\x45\n\nItemsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12&\n\x05value\x18\x02 \x01(\x0b\x32\x17.compas_pb.data.AnyData:\x02\x38\x01\"4\n\x0bMessageData\x12%\n\x04\x64\x61ta\x18\x01 \x01(\x0b\x32\x17.compas_pb.data.AnyDatab\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -35,14 +35,16 @@ if not _descriptor._USE_C_DESCRIPTORS:
   DESCRIPTOR._loaded_options = None
   _globals['_DICTDATA_ITEMSENTRY']._loaded_options = None
   _globals['_DICTDATA_ITEMSENTRY']._serialized_options = b'8\001'
-  _globals['_ANYDATA']._serialized_start=110
-  _globals['_ANYDATA']._serialized_end=209
-  _globals['_LISTDATA']._serialized_start=211
-  _globals['_LISTDATA']._serialized_end=261
-  _globals['_DICTDATA']._serialized_start=264
-  _globals['_DICTDATA']._serialized_end=397
-  _globals['_DICTDATA_ITEMSENTRY']._serialized_start=328
-  _globals['_DICTDATA_ITEMSENTRY']._serialized_end=397
-  _globals['_MESSAGEDATA']._serialized_start=399
-  _globals['_MESSAGEDATA']._serialized_end=451
+  _globals['_ANYDATA']._serialized_start=111
+  _globals['_ANYDATA']._serialized_end=260
+  _globals['_FALLBACKDATA']._serialized_start=262
+  _globals['_FALLBACKDATA']._serialized_end=316
+  _globals['_LISTDATA']._serialized_start=318
+  _globals['_LISTDATA']._serialized_end=368
+  _globals['_DICTDATA']._serialized_start=371
+  _globals['_DICTDATA']._serialized_end=504
+  _globals['_DICTDATA_ITEMSENTRY']._serialized_start=435
+  _globals['_DICTDATA_ITEMSENTRY']._serialized_end=504
+  _globals['_MESSAGEDATA']._serialized_start=506
+  _globals['_MESSAGEDATA']._serialized_end=558
 # @@protoc_insertion_point(module_scope)

--- a/src/compas_pb/protobuf_defs/compas_pb/generated/message.proto
+++ b/src/compas_pb/protobuf_defs/compas_pb/generated/message.proto
@@ -10,7 +10,12 @@ message AnyData {
   oneof data {
     google.protobuf.Any message = 1;
     google.protobuf.Value value = 2;
+    FallbackData fallback = 3;
   }
+}
+
+message FallbackData {
+    DictData data = 1;
 }
 
 /** repeated serves as a list in protobuf */

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -1,15 +1,21 @@
+from unittest.mock import patch
+
 from compas.datastructures import Graph
+from compas.geometry import Point
 from compas_pb import pb_dump_json
 from compas_pb import pb_load_json
+from compas_pb.registry import SerializerRegistry
 
 
 def test_graph_fallback_serialization():
+    """Test that Graph uses fallback serialization by patching the serializer registry."""
     graph = Graph()
     graph.add_node(0, name="A")
     graph.add_node(1, name="B")
     graph.add_edge(0, 1)
 
-    json_data = pb_dump_json(graph)
+    with patch.object(SerializerRegistry, "get_serializer", return_value=None):
+        json_data = pb_dump_json(graph)
 
     loaded_graph = pb_load_json(json_data)
 
@@ -18,3 +24,18 @@ def test_graph_fallback_serialization():
     assert loaded_graph.number_of_edges() == 1
     assert loaded_graph.node_attribute(0, "name") == "A"
     assert loaded_graph.node_attribute(1, "name") == "B"
+
+
+def test_forced_fallback_serialization():
+    """Test that patching the serializer registry forces fallback serialization for a normally supported type."""
+    point = Point(1.0, 2.0, 3.0)
+
+    with patch.object(SerializerRegistry, "get_serializer", return_value=None):
+        json_data = pb_dump_json(point)
+
+    loaded_point = pb_load_json(json_data)
+
+    assert isinstance(loaded_point, Point)
+    assert loaded_point.x == 1.0
+    assert loaded_point.y == 2.0
+    assert loaded_point.z == 3.0

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -1,0 +1,20 @@
+from compas.datastructures import Graph
+from compas_pb import pb_dump_json
+from compas_pb import pb_load_json
+
+
+def test_graph_fallback_serialization():
+    graph = Graph()
+    graph.add_node(0, name="A")
+    graph.add_node(1, name="B")
+    graph.add_edge(0, 1)
+
+    json_data = pb_dump_json(graph)
+
+    loaded_graph = pb_load_json(json_data)
+
+    assert isinstance(loaded_graph, Graph)
+    assert loaded_graph.number_of_nodes() == 2
+    assert loaded_graph.number_of_edges() == 1
+    assert loaded_graph.node_attribute(0, "name") == "A"
+    assert loaded_graph.node_attribute(1, "name") == "B"


### PR DESCRIPTION
This PR introduces an end-to-end fallback mechanism for serializing and de-serializing `compas.data.Data` types using `compas_pb`.

Types which are not known to `compa_pb` (i.e. there's no `.proto` definition and/or no serializers registered for them) but do implement `compas.data.Data` fallback to be serialized and deserialized using the good old `Data` dictionary.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
