### PR TITLE
set executable flag on mac as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fixed running `protoc` fails with permission denied on Mac.
+
 ### Removed
 
 

--- a/src/compas_pb/invocations.py
+++ b/src/compas_pb/invocations.py
@@ -105,7 +105,7 @@ def setup_protoc():
         docsplugin_url = _get_docsplugin_download_url()
         _download_and_extract_docsplugin(docsplugin_url, protoc_bin.parent)
 
-        if platform.system() == "Linux":
+        if platform.system() in ["Linux", "Darwin"]:
             mode = os.stat(protoc_bin)
             os.chmod(protoc_bin, mode.st_mode | stat.S_IEXEC)
 


### PR DESCRIPTION
Generating proto files fails on the github action mac machine, I suspect it's due to not setting the binary as executable.
